### PR TITLE
Ignore source videos

### DIFF
--- a/courseradownloader/courseradownloader.py
+++ b/courseradownloader/courseradownloader.py
@@ -166,6 +166,10 @@ class CourseraDownloader(object):
                 # (dont set a filename here, that will be inferred from the week
                 # titles)
                 resourceLinks = [ (h['href'],None) for h in hrefs]
+                # Ignore source_videos, they are huge and available compressed 
+                for x,_ in resourceLinks:
+                    if x.find('source_videos') > 0:
+                        print "Not downloading " + x['href'] + " since it is a source video."
                 resourceLinks = [ (x,None) for x,_ in resourceLinks if x.find('source_videos') <=0 ]
  
                 # check if the video is included in the resources, if not, try

--- a/courseradownloader/courseradownloader.py
+++ b/courseradownloader/courseradownloader.py
@@ -166,6 +166,7 @@ class CourseraDownloader(object):
                 # (dont set a filename here, that will be inferred from the week
                 # titles)
                 resourceLinks = [ (h['href'],None) for h in hrefs]
+                resourceLinks = [ (x,None) for x,_ in resourceLinks if x.find('source_videos') <=0 ]
  
                 # check if the video is included in the resources, if not, try
                 # do download it directly


### PR DESCRIPTION
The source video's can be huge, (e.g. healthinformatics-001), and the same video is available compressed.
