### PR TITLE
Fixing KeyError that arises 'a' tags are missing hrefs

### DIFF
--- a/courseradownloader/courseradownloader.py
+++ b/courseradownloader/courseradownloader.py
@@ -191,7 +191,8 @@ class CourseraDownloader(object):
 
                 for a in hrefs:
                     # get the hyperlink itself
-                    h = a['href']
+                    h = a.get('href')
+                    if not h: continue
 
                     # Sometimes the raw, uncompresed source videos are available as
                     # well. Don't download them as they are huge and available in


### PR DESCRIPTION
Though I have no idea why this happens when a page is retrieved by script as it doesn't seem to in the browser's source view. I've confirmed that the tags this affects look like "<a target="_"></a>" and don't seem to interfere with any of the valid content on the page.
