### PR TITLE
Detecting renamed files

### DIFF
--- a/courseradownloader/courseradownloader.py
+++ b/courseradownloader/courseradownloader.py
@@ -295,6 +295,13 @@ class CourseraDownloader(object):
                 # missing or invalid content length
                 # assume all is ok...
                 dl = False
+        else:
+            # Detect renamed files
+            existing, short = find_renamed(filepath, clen)
+            if existing:
+                print '    - "%s" seems to be a copy of "%s", renaming existing file' % (fname, short)
+                os.rename(existing, filepath)
+                dl = False
 
         try:
            if dl:
@@ -574,6 +581,28 @@ def get_netrc_creds():
             pass
 
     return creds
+
+
+def normalize_string(str):
+    return ''.join(x for x in str if x not in ' \t-_()"01234567890').lower()
+
+
+def find_renamed(filename, size):
+    fpath, name = path.split(filename)
+    name, ext = path.splitext(name)
+    name = normalize_string(name)
+
+    files = os.listdir(fpath)
+    for f in files:
+        fname, fext = path.splitext(f)
+        fname = normalize_string(fname)
+        if fname == name and fext == ext:
+            fullname = os.path.join(fpath, f)
+            if path.getsize(fullname) == size:
+                return fullname, f
+
+    return None
+
 
 def main():
     # parse the commandline arguments

--- a/courseradownloader/courseradownloader.py
+++ b/courseradownloader/courseradownloader.py
@@ -304,7 +304,7 @@ class CourseraDownloader(object):
                 dl = False
 
         try:
-           if dl:
+            if dl:
                 self.browser.retrieve(url,filepath,timeout=self.TIMEOUT)
         except Exception as e:
             print "Failed to download url %s to %s: %s" % (url,filepath,e)
@@ -592,16 +592,20 @@ def find_renamed(filename, size):
     name, ext = path.splitext(name)
     name = normalize_string(name)
 
-    files = os.listdir(fpath)
-    for f in files:
-        fname, fext = path.splitext(f)
-        fname = normalize_string(fname)
-        if fname == name and fext == ext:
-            fullname = os.path.join(fpath, f)
-            if path.getsize(fullname) == size:
-                return fullname, f
+    if not path.exists(fpath):
+        return None, None
 
-    return None
+    files = os.listdir(fpath)
+    if files:
+        for f in files:
+            fname, fext = path.splitext(f)
+            fname = normalize_string(fname)
+            if fname == name and fext == ext:
+                fullname = os.path.join(fpath, f)
+                if path.getsize(fullname) == size:
+                    return fullname, f
+
+    return None, None
 
 
 def main():


### PR DESCRIPTION
## File rename detection

Coursera professors often re-organize course content while a course is running and this leads to changes in topic / unit names, which leads to coursera-dl downloading the same content again under different names.

This change is aimed to detect renames and reuse already downloaded files. Directory renames are not detected at this moment.
## A separate deduplication project

I've also created a separate project for removing duplicates in already downloaded content. This one is capable of detecting directory renames. Feel free to include this in your project or just put a link in your project description.
https://github.com/ilfats/dedup.git
