### PR TITLE
Fixes issue #84

### DIFF
--- a/courseradownloader/courseradownloader.py
+++ b/courseradownloader/courseradownloader.py
@@ -170,7 +170,7 @@ class CourseraDownloader(object):
             classNames = []
             for li in lis:
                 # the name of this lecture/class
-                className = li.a.text.strip()
+                className = li.a.find(text=True).strip()
 
                 # Many class names have the following format: 
                 #   "Something really cool (12:34)"


### PR DESCRIPTION
Grab the text contents of the very first text node, because Coursera may append trailing text if you attempt a quiz
