### PR TITLE
generating html output with lectures and resources list

### DIFF
--- a/courseradownloader/courseradownloader.py
+++ b/courseradownloader/courseradownloader.py
@@ -486,7 +486,7 @@ class CourseraDownloader(object):
             file.write(self.HTML_TEMPLATE % self.html)
             file.close()
         except Exception as e:
-           print "  - Writing materials.html failed: ",e
+            print "  - Writing materials.html failed: ",e 
 
         if gzip_courses:
             tar_file_name = cname + ".tar.gz"


### PR DESCRIPTION
The new code generates an html file (`materials.html`) with a list of lectures and their materials (pdfs, mp4 etc.) as downloaded. This file makes it easy to access various downloaded resources without traversing week/lecture directory tree on the file system. (Unfortunately, the downloaded `index.html` and `lectures.html` files don't show the list of lectures and resources - see dgorissen/coursera-dl#157.)

Here's how this new html file looks like for the "Functional Programming Principles in Scala" course:

![image](https://cloud.githubusercontent.com/assets/2960711/4909366/bb52d4b0-6472-11e4-9129-5ab07b99e640.png)
